### PR TITLE
Update Dockerfile

### DIFF
--- a/assets/Dockerfile
+++ b/assets/Dockerfile
@@ -1,4 +1,4 @@
-FROM ibmsemeruruntime/open-8-jdk:ubi-jdk-latest as staging
+FROM ibmsemeruruntime/open-8-jdk:ubi-jdk as staging
 
 # Define the variables for the OpenSSL subject.
 ARG COUNTRY=CA


### PR DESCRIPTION
Updated the tag, as `ubi-jdk-latest` is no longer a tag available for the [ibmsemeruruntime/open-8-jdk](https://hub.docker.com/r/ibmsemeruruntime/open-8-jdk/tags?page=1) docker image.