### PR TITLE
Update Dockerfile

### DIFF
--- a/assets/Dockerfile
+++ b/assets/Dockerfile
@@ -42,7 +42,7 @@ COPY assets/index.js /home/mongodb
 RUN mongod \
         --fork \
         --config /home/mongodb/mongodb.conf \
-    && mongo \
+    && mongosh \
         testdb \
         -tls \
         --tlsCAFile /home/mongodb/certs/cert.pem \


### PR DESCRIPTION
Failed to build the MongoDB docker image. The problem was caused https://www.mongodb.com/docs/manual/release-notes/6.0-compatibility/#legacy-mongo-shell-removed