### PR TITLE
Update to MP6.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 50

--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -1,0 +1,18 @@
+name: Add PRs to Dependabot PRs dashboard
+
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+
+jobs:
+  add-to-project:
+    name: Add PR to dashboard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/OpenLiberty/projects/26
+          github-token: ${{ secrets.ADMIN_BACKLOG }}
+          labeled: dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,13 +61,11 @@ jobs:
       if: always()
       run: | 
           logsPath=$(sudo find . -name "console.log");
-          echo $logsPath
           sudo cat $logsPath | sudo grep Launching
-          sudo chmod -R 777 $logsPath/..
           
     - name: Archive server logs if failed
       if: failure()
       uses: actions/upload-artifact@v2
       with:
         name: server-logs
-        path: finish/target/liberty/wlp/usr/servers/defaultServer/logs/
+        path: ./target/liberty/wlp/usr/servers/defaultServer/logs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
           
     - name: Archive server logs if failed
       if: failure()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: server-logs
         path: ./target/liberty/wlp/usr/servers/defaultServer/logs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,9 +60,10 @@ jobs:
     - name: Post tests
       if: always()
       run: | 
-          logsPath=$(sudo find . -name "console.log");  
+          logsPath=$(sudo find . -name "console.log");
+          echo $logsPath
           sudo cat $logsPath | sudo grep Launching
-          sudo chmod -R 777 finish/target/liberty/wlp/usr/servers/defaultServer/logs/
+          sudo chmod -R 777 $logsPath/..
           
     - name: Archive server logs if failed
       if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
       run: | 
           logsPath=$(sudo find . -name "console.log");  
           sudo cat $logsPath | sudo grep Launching
-          chmod -R 777 finish/target/liberty/wlp/usr/servers/defaultServer/logs/
+          sudo chmod -R 777 finish/target/liberty/wlp/usr/servers/defaultServer/logs/
           
     - name: Archive server logs if failed
       if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,7 @@ jobs:
       run: | 
           logsPath=$(sudo find . -name "console.log");  
           sudo cat $logsPath | sudo grep Launching
+          chmod -R 777 finish/target/liberty/wlp/usr/servers/defaultServer/logs/
           
     - name: Archive server logs if failed
       if: failure()

--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-//  Copyright (c) 2020, 2024 IBM Corporation and others.
+//  Copyright (c) 2020, 2023 IBM Corporation and others.
 // Licensed under Creative Commons Attribution-NoDerivatives
 // 4.0 International (CC BY-ND 4.0)
 //   https://creativecommons.org/licenses/by-nd/4.0/
@@ -14,7 +14,7 @@
 :page-essential-order: 1
 :page-description: Learn how to persist data in Java microservices to MongoDB, a document-oriented NoSQL database.
 :guide-author: Open Liberty
-:page-tags: ['microprofile', 'jakarta-ee']
+:page-tags: ['MicroProfile', 'Jakarta EE']
 :page-related-guides: ['cdi-intro', 'microprofile-config', 'rest-intro']
 :page-permalink: /guides/{projectid}
 :repo-description: Visit the https://openliberty.io/guides/{projectid}.html[website] for the rendered version of the guide.
@@ -199,7 +199,7 @@ include::finish/src/main/liberty/config/server.xml[]
 
 The values from the [hotspot file=1]`microprofile-config.properties` file are injected into the [hotspot=mongoProducerInjections file=0]`MongoProducer` class. The `MongoProducer` class requires the following methods for the `MongoClient`:
 
-* The [hotspot=createMongo file=0]`createMongo()` producer method returns an instance of `MongoClient`. In this method, the username, database name, and decoded password are passed into the [hotspot=createCredential file=0]`MongoCredential.createCredential()` method to get an instance of `MongoCredential`. The [hotspot=MongoClientSettings file=0]`MongoClientSettings` prepares the configuration. Then, a [hotspot=mongoClient file=0]`MongoClient` instance is created with the configuration.
+* The [hotspot=createMongo file=0]`createMongo()` producer method returns an instance of `MongoClient`. In this method, the username, database name, and decoded password are passed into the [hotspot=createCredential file=0]`MongoCredential.createCredential()` method to get an instance of `MongoCredential`. The [hotspot=sslContext file=0]`JSSEHelper` gets the `SSLContext` from the `outboundSSLContext` in the `server.xml` configuration file. Then, a [hotspot=mongoClient file=0]`MongoClient` instance is created.
 
 * The [hotspot=createDB file=0]`createDB()` producer method returns an instance of `MongoDatabase` that depends on the `MongoClient`. This method injects the `MongoClient` in its parameters and passes the database name into the [hotspot=getDatabase file=0]`MongoClient.getDatabase()` method to get a `MongoDatabase` instance.
 

--- a/README.adoc
+++ b/README.adoc
@@ -14,7 +14,7 @@
 :page-essential-order: 1
 :page-description: Learn how to persist data in Java microservices to MongoDB, a document-oriented NoSQL database.
 :guide-author: Open Liberty
-:page-tags: ['microfrofile', 'jakarta-ee']
+:page-tags: ['microprofile', 'jakarta-ee']
 :page-related-guides: ['cdi-intro', 'microprofile-config', 'rest-intro']
 :page-permalink: /guides/{projectid}
 :repo-description: Visit the https://openliberty.io/guides/{projectid}.html[website] for the rendered version of the guide.

--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-//  Copyright (c) 2020, 2023 IBM Corporation and others.
+//  Copyright (c) 2020, 2024 IBM Corporation and others.
 // Licensed under Creative Commons Attribution-NoDerivatives
 // 4.0 International (CC BY-ND 4.0)
 //   https://creativecommons.org/licenses/by-nd/4.0/
@@ -14,7 +14,7 @@
 :page-essential-order: 1
 :page-description: Learn how to persist data in Java microservices to MongoDB, a document-oriented NoSQL database.
 :guide-author: Open Liberty
-:page-tags: ['MicroProfile', 'Jakarta EE']
+:page-tags: ['microprofile', 'jakarta-ee']
 :page-related-guides: ['cdi-intro', 'microprofile-config', 'rest-intro']
 :page-permalink: /guides/{projectid}
 :repo-description: Visit the https://openliberty.io/guides/{projectid}.html[website] for the rendered version of the guide.
@@ -514,7 +514,6 @@ Then, run the following commands to stop and remove the `mongo-guide` container 
 docker stop mongo-guide
 docker rm mongo-guide
 docker rmi mongo-sample
-docker rmi mongo
 ```
 
 == Great work! You're done!

--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-//  Copyright (c) 2020, 2023 IBM Corporation and others.
+//  Copyright (c) 2020, 2024 IBM Corporation and others.
 // Licensed under Creative Commons Attribution-NoDerivatives
 // 4.0 International (CC BY-ND 4.0)
 //   https://creativecommons.org/licenses/by-nd/4.0/
@@ -14,7 +14,7 @@
 :page-essential-order: 1
 :page-description: Learn how to persist data in Java microservices to MongoDB, a document-oriented NoSQL database.
 :guide-author: Open Liberty
-:page-tags: ['MicroProfile', 'Jakarta EE']
+:page-tags: ['microfrofile', 'jakarta-ee']
 :page-related-guides: ['cdi-intro', 'microprofile-config', 'rest-intro']
 :page-permalink: /guides/{projectid}
 :repo-description: Visit the https://openliberty.io/guides/{projectid}.html[website] for the rendered version of the guide.
@@ -199,7 +199,7 @@ include::finish/src/main/liberty/config/server.xml[]
 
 The values from the [hotspot file=1]`microprofile-config.properties` file are injected into the [hotspot=mongoProducerInjections file=0]`MongoProducer` class. The `MongoProducer` class requires the following methods for the `MongoClient`:
 
-* The [hotspot=createMongo file=0]`createMongo()` producer method returns an instance of `MongoClient`. In this method, the username, database name, and decoded password are passed into the [hotspot=createCredential file=0]`MongoCredential.createCredential()` method to get an instance of `MongoCredential`. The [hotspot=sslContext file=0]`JSSEHelper` gets the `SSLContext` from the `outboundSSLContext` in the `server.xml` configuration file. Then, a [hotspot=mongoClient file=0]`MongoClient` instance is created.
+* The [hotspot=createMongo file=0]`createMongo()` producer method returns an instance of `MongoClient`. In this method, the username, database name, and decoded password are passed into the [hotspot=createCredential file=0]`MongoCredential.createCredential()` method to get an instance of `MongoCredential`. The [hotspot=MongoClientSettings file=0]`MongoClientSettings` prepares the configuration. Then, a [hotspot=mongoClient file=0]`MongoClient` instance is created with the configuration.
 
 * The [hotspot=createDB file=0]`createDB()` producer method returns an instance of `MongoDatabase` that depends on the `MongoClient`. This method injects the `MongoClient` in its parameters and passes the database name into the [hotspot=getDatabase file=0]`MongoClient.getDatabase()` method to get a `MongoDatabase` instance.
 

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -69,8 +69,8 @@
         <!-- tag::mongoDriver[] -->
         <dependency>
             <groupId>org.mongodb</groupId>
-            <artifactId>mongo-java-driver</artifactId>
-            <version>3.12.13</version>
+            <artifactId>mongodb-driver-sync</artifactId>
+            <version>4.11.1</version>
         </dependency>
         <!-- end::mongoDriver[] -->
         <!-- For tests -->

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -16,10 +16,10 @@
         <!-- OpenLiberty runtime -->
         <version.openliberty-runtime>RELEASE</version.openliberty-runtime>
         <!-- tag::defaultHttpPort[] -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
+        <liberty.var.http.port>9080</liberty.var.http.port>
         <!-- end::defaultHttpPort[] -->
         <!-- tag::defaultHttpsPort[] -->
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.https.port>9443</liberty.var.https.port>
         <!-- end::defaultHttpsPort[] -->
         <app.name>${project.artifactId}</app.name>
         <!-- tag::appContextRoot[] -->
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>com.ibm.websphere.appserver.api</groupId>
             <artifactId>com.ibm.websphere.appserver.api.passwordUtil</artifactId>
-            <version>1.0.75</version>
+            <version>1.0.84</version>
             <scope>provided</scope>
         </dependency>
         <!-- end::passwordUtilDependency[] -->
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>com.ibm.websphere.appserver.api</groupId>
             <artifactId>com.ibm.websphere.appserver.api.ssl</artifactId>
-            <version>1.5.75</version>
+            <version>1.6.84</version>
             <scope>provided</scope>
         </dependency>
         <!-- end::sslDependency[] -->
@@ -77,13 +77,13 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-json-binding-provider</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -119,23 +119,23 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <!-- tag::testsysprops[] -->
                     <systemPropertyVariables>
-                        <app.http.port>${liberty.var.default.http.port}</app.http.port>
+                        <app.http.port>${liberty.var.http.port}</app.http.port>
                         <app.context.root>${liberty.var.app.context.root}</app.context.root>
                     </systemPropertyVariables>
                     <!-- end::testsysprops[] -->

--- a/finish/src/main/java/io/openliberty/guides/mongo/MongoProducer.java
+++ b/finish/src/main/java/io/openliberty/guides/mongo/MongoProducer.java
@@ -83,7 +83,7 @@ public class MongoProducer {
         );
         // end::sslContext[]
 
-        // tag::mongoClient[] 
+        // tag::mongoClient[]
         return MongoClients.create(MongoClientSettings.builder()
                    .applyConnectionString(
                        new ConnectionString("mongodb://" + hostname + ":" + port))

--- a/finish/src/main/java/io/openliberty/guides/mongo/MongoProducer.java
+++ b/finish/src/main/java/io/openliberty/guides/mongo/MongoProducer.java
@@ -11,7 +11,6 @@
 // end::copyright[]
 package io.openliberty.guides.mongo;
 
-import java.util.Arrays;
 import java.util.Collections;
 
 import javax.net.ssl.SSLContext;
@@ -21,13 +20,12 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import com.ibm.websphere.crypto.PasswordUtil;
 import com.ibm.websphere.ssl.JSSEHelper;
 import com.ibm.websphere.ssl.SSLException;
+import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoCredential;
-import com.mongodb.ServerAddress;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
-import com.mongodb.connection.SslSettings;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Disposes;
@@ -85,15 +83,14 @@ public class MongoProducer {
         );
         // end::sslContext[]
 
-        // tag::mongoClient[]
+        // tag::mongoClient[] 
         return MongoClients.create(MongoClientSettings.builder()
+                   .applyConnectionString(
+                       new ConnectionString("mongodb://" + hostname + ":" + port))
                    .credential(creds)
-                   .applyToSslSettings(builder ->
-                       builder.enabled(true)
-                              .applySettings(
-                                  SslSettings.builder().context(sslContext).build()))
-                   .applyToClusterSettings(builder ->
-                       builder.hosts(Arrays.asList(new ServerAddress(hostname, port))))
+                   .applyToSslSettings(builder -> {
+                       builder.enabled(true);
+                       builder.context(sslContext); })
                    .build());
         // end::mongoClient[]
     }

--- a/finish/src/main/java/io/openliberty/guides/mongo/MongoProducer.java
+++ b/finish/src/main/java/io/openliberty/guides/mongo/MongoProducer.java
@@ -74,7 +74,7 @@ public class MongoProducer {
         MongoClientSettings settings = MongoClientSettings.builder()
             .credential(creds)
             .applyToSslSettings(builder -> builder.enabled(true))
-            .applyToClusterSettings(builder -> 
+            .applyToClusterSettings(builder ->
                 builder.hosts(Arrays.asList(new ServerAddress(hostname, port))))
             .build();
         // end::mongoClientSettings[]

--- a/finish/src/main/liberty/config/server.xml
+++ b/finish/src/main/liberty/config/server.xml
@@ -8,7 +8,7 @@
         <feature>ssl-1.0</feature>
         <!-- end::sslFeature[] -->
         <!-- tag::mpConfigFeature[] -->
-        <feature>mpConfig-3.0</feature>
+        <feature>mpConfig-3.1</feature>
         <!-- end::mpConfigFeature[] -->
         <!-- tag::passwordUtilFeature[] -->
         <feature>passwordUtilities-1.1</feature>
@@ -20,15 +20,15 @@
     </featureManager>
     <!-- end::featureManager[] -->
 
-    <variable name="default.http.port" defaultValue="9080"/>
-    <variable name="default.https.port" defaultValue="9443"/>
+    <variable name="http.port" defaultValue="9080"/>
+    <variable name="https.port" defaultValue="9443"/>
     <variable name="app.context.root" defaultValue="/mongo"/>
 
     <!-- tag::httpEndpoint[] -->
     <httpEndpoint
         host="*" 
-        httpPort="${default.http.port}" 
-        httpsPort="${default.https.port}" 
+        httpPort="${http.port}" 
+        httpsPort="${https.port}" 
         id="defaultHttpEndpoint"
     />
     <!-- end::httpEndpoint[] -->

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -69,8 +69,8 @@
         <!-- tag::mongoDriver[] -->
         <dependency>
             <groupId>org.mongodb</groupId>
-            <artifactId>mongo-java-driver</artifactId>
-            <version>3.12.13</version>
+            <artifactId>mongodb-driver-sync</artifactId>
+            <version>4.11.1</version>
         </dependency>
         <!-- end::mongoDriver[] -->
         <!-- For tests -->

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -16,10 +16,10 @@
         <!-- OpenLiberty runtime -->
         <version.openliberty-runtime>RELEASE</version.openliberty-runtime>
         <!-- tag::defaultHttpPort[] -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
+        <liberty.var.http.port>9080</liberty.var.http.port>
         <!-- end::defaultHttpPort[] -->
         <!-- tag::defaultHttpsPort[] -->
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.https.port>9443</liberty.var.https.port>
         <!-- end::defaultHttpsPort[] -->
         <app.name>${project.artifactId}</app.name>
         <!-- tag::appContextRoot[] -->
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>com.ibm.websphere.appserver.api</groupId>
             <artifactId>com.ibm.websphere.appserver.api.passwordUtil</artifactId>
-            <version>1.0.75</version>
+            <version>1.0.84</version>
             <scope>provided</scope>
         </dependency>
         <!-- end::passwordUtilDependency[] -->
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>com.ibm.websphere.appserver.api</groupId>
             <artifactId>com.ibm.websphere.appserver.api.ssl</artifactId>
-            <version>1.5.75</version>
+            <version>1.6.84</version>
             <scope>provided</scope>
         </dependency>
         <!-- end::sslDependency[] -->
@@ -77,13 +77,13 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-json-binding-provider</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -119,23 +119,23 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <!-- tag::testsysprops[] -->
                     <systemPropertyVariables>
-                        <app.http.port>${liberty.var.default.http.port}</app.http.port>
+                        <app.http.port>${liberty.var.http.port}</app.http.port>
                         <app.context.root>${liberty.var.app.context.root}</app.context.root>
                     </systemPropertyVariables>
                     <!-- end::testsysprops[] -->

--- a/start/src/main/liberty/config/server.xml
+++ b/start/src/main/liberty/config/server.xml
@@ -1,16 +1,16 @@
 <server description="Sample Liberty server">
     <featureManager>
-        <feature>mpConfig-3.0</feature>
+        <feature>mpConfig-3.1</feature>
     </featureManager>
 
-    <variable name="default.http.port" defaultValue="9080"/>
-    <variable name="default.https.port" defaultValue="9443"/>
+    <variable name="http.port" defaultValue="9080"/>
+    <variable name="https.port" defaultValue="9443"/>
     <variable name="app.context.root" defaultValue="/mongo"/>
 
     <httpEndpoint
         host="*" 
-        httpPort="${default.http.port}" 
-        httpsPort="${default.https.port}" 
+        httpPort="${http.port}" 
+        httpsPort="${https.port}" 
         id="defaultHttpEndpoint"
     />
 


### PR DESCRIPTION
address issue: https://github.com/OpenLiberty/guides-common/issues/1021

### Review changes
- [ ] pom.xml
  - microfile-profile is 6.1, and dependencies
  - LMP 3.10
  - `default.` should be removed
  - ports `9090`,`9453`,`9091`,`9454` if guide uses local kube
- [ ] server.xml
  - feature version
- [ ] index.html
  - feature version
- [ ] update lgdev with `version-update-mp61` branch
- [ ] do end-to-end test and review content carefully
  - clone the `version-update-mp61` branch
  - if index.html has changes, make sure the links work

