### PR TITLE
temporary fix the cloud-hosted guide to use mongodb v7

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -79,11 +79,21 @@ You can find more details and configuration options on the https://docs.mongodb.
 
 Run the following commands to use the Dockerfile to build the image, run the image in a Docker container, and map port `27017` from the container to your host machine:
 
+ifndef::cloud-hosted[]
 [role='command']
 ```
 docker build -t mongo-sample -f assets/Dockerfile .
 docker run --name mongo-guide -p 27017:27017 -d mongo-sample
 ```
+endif::[]
+
+ifdef::cloud-hosted[]
+```bash
+sed -i 's=latest=7.0.15-rc1=g' assets/Dockerfile
+docker build -t mongo-sample -f assets/Dockerfile .
+docker run --name mongo-guide -p 27017:27017 -d mongo-sample
+```
+endif::[]
 
 **Adding the truststore to the Open Liberty configuration**
 

--- a/README.adoc
+++ b/README.adoc
@@ -113,7 +113,7 @@ docker cp ^
   finish/src/main/liberty/config/resources/security
 ```
 --
-[.tab_content.linux_section]
+[.tab_content.mac_section]
 --
 [role='command']
 ```
@@ -125,7 +125,7 @@ docker cp \
   finish/src/main/liberty/config/resources/security
 ```
 --
-[.tab_content.mac_section]
+[.tab_content.linux_section]
 --
 [role='command']
 ```


### PR DESCRIPTION
update the Dockerfile to use `mongodb:7.0.15-rc1`