### PR TITLE
Fix casings warning in docker file

### DIFF
--- a/assets/Dockerfile
+++ b/assets/Dockerfile
@@ -1,4 +1,4 @@
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi as staging
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi AS staging
 
 # Define the variables for the OpenSSL subject.
 ARG COUNTRY=CA


### PR DESCRIPTION
Previous:
<img width="716" height="293" alt="image" src="https://github.com/user-attachments/assets/975ac59f-d182-4886-9272-56f5392842a2" />

Current after changes:
<img width="715" height="382" alt="image" src="https://github.com/user-attachments/assets/1c2d66ff-c6ca-4ff0-a5fc-3c9e586497b2" />

